### PR TITLE
Add `/utf8` codec

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,9 @@ prefix - codec - desc
 0x052f6235382f - /b58/ - ascii base58
 0x052f6236342f - /b64/ - ascii base64
 
+// unicode text
+0xefbbbf - /utf8/ - UTF-8 encoded text
+
 // the JSONs
 062f6a736f6e2f      - /json/
 062f63626f722f      - /cbor/


### PR DESCRIPTION
The prefix has been chosen to be compatible with the [UTF-8 BOM](https://en.wikipedia.org/wiki/Byte_order_mark#UTF-8)